### PR TITLE
Customizing endpoint to match with the one in the config/laraform.php file

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -1,5 +1,7 @@
 <?php
 
 Route::group(['middleware' => 'web'], function () {
-    Route::post('/laraform/process', '\Laraform\Controllers\FormController@process');
+    $method = strtolower(config('laraform.method'));
+
+    Route::$method(config('laraform.endpoint'), '\Laraform\Controllers\FormController@process');
 });


### PR DESCRIPTION
This change allows you to fully customize the default endpoint for submitting the data to the backend directly from the `config/laraform.php` file without having you to put an additional custom endpoint in your routes file and still exposing the default one.

The problem without this fix is that even if you customize the config file, the default endpoint is still exposed AND you still need to basically "copy" the logic in this routes file in your own routes file with your custom endpoint name.

Another workaround ideally would be to have an option in the config file to disable this default route. So that way if you change the default endpoint in the config file, you can also disable the default routes.php file so this `/laraform/process` endpoint is not exposed anymore.

What do you think? Plan A,  alternative B or none?